### PR TITLE
Update service to use fixed directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,13 @@
-This is a simple python script which deletes files periodically every 24 hours.
+This service deletes every file and subfolder from a fixed temporary directory
+once every 24 hours.  The folder is chosen automatically: if
+`D:\TempStorage` exists it will be cleaned, otherwise `C:\TempStorage` is used.
 
 ------ Installing ------
 
-Method 1)
-
-Bash cmd admin at script location:
+Installation (run from an elevated command prompt):
 ````
 python cleanup_service.py --startup auto install
 ````
-
-Method 2) 
-- Run install_service.bat as administrator
-- When Promted enter the target temporary folder and hit enter
-- Script creates `C:\FileCleanupConfig\config.txt`
-- config.txt get read every 5 minutes.
-- If any changes have been made, the target folder changes.
   
 ---- Managing the Service ------
 


### PR DESCRIPTION
## Summary
- simplify service to remove config file logic
- choose temp dir automatically (`D:\TempStorage` or fallback `C:\TempStorage`)
- update install instructions in README

## Testing
- `python -m py_compile cleanup_service.py`


------
https://chatgpt.com/codex/tasks/task_e_684b52950fcc8322b7c0dc940c1ac8a2